### PR TITLE
Sets ad unit explicitly

### DIFF
--- a/views/includes/html-head.html
+++ b/views/includes/html-head.html
@@ -176,11 +176,8 @@
 <script data-o-ads-config="" type="application/json">
 {
   "gpt": {
-    "network": 5887,
-    "site": "{{ ads.gptSite }}"
-    {%- if ads.gptZone %}, "zone": "{{ ads.gptZone }}"{% endif %}
+    "unitName" : "5887/ft.com/educating.chinese.leaders"
   }
-  {%- if ads.dfpTargeting %}, "dfp_targeting": "{{ ads.dfpTargeting }}"{%- endif %}
 }
 </script>
 {% endif %}


### PR DESCRIPTION
As per discussion from #graphics-help, this sets the ad unit to `5887/ft.com/educating.chinese.leaders`.